### PR TITLE
Add custom context snippet under "!ctx"

### DIFF
--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -389,6 +389,17 @@
 		],
         "description": "Add a basic select."
 	},
+    "discord.py Custom Context":{
+        "prefix": "!ctx",
+        "body": [
+            "from discord.ext import commands",
+            "",
+            "",
+            "class ${1:Context}(commands.Context):",
+            "    async def send(self, ctx: commands.Context):",
+            "        $0"
+        ]
+    },
 
 }
 


### PR DESCRIPTION
Wanted custom context snippets as I write them relatively frequently across multiple projects.

Ignore the commit name, made a mistake when writing.